### PR TITLE
Connection Timeout for Health Check Requests

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/golang/glog"
 	"github.com/prometheus/client_golang/prometheus"
@@ -31,7 +32,10 @@ type Exporter struct {
 }
 
 func NewExporter(servicesConfig *Config) *Exporter {
-	httpClient := &http.Client{}
+	timeout := time.Duration(0.5 * time.Second)
+	httpClient := &http.Client{
+		Timeout: timeout,
+	}
 
 	return &Exporter{
 		client: httpClient,


### PR DESCRIPTION
Under certain conditions it is possible for health check requests to never return. This commit adds a connection timeout to the http client in order to prevent this from bringing down the entire health exporter. The problem can be easily reproduced by adding a non-routable IP (like 10.255.255.1) as health check target to the configuration.
