### PR TITLE
Add command line flag to define custom timeout for health check requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ health-exporter
 
 *.sublime-project
 *.sublime-workspace
+
+*.local.sh
+Dockerfile.local

--- a/config.go
+++ b/config.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"time"
+
 	"encoding/json"
 	"io/ioutil"
 )
@@ -11,7 +13,8 @@ type Service struct {
 }
 
 type Config struct {
-	Services []Service `json:"services"`
+	RequestTimeoutMillis int64     `json:"requestTimeoutMillis"`
+	Services             []Service `json:"services"`
 }
 
 func readConfig(file string) (*Config, error) {
@@ -39,4 +42,12 @@ func (c *Config) collectUniqueLabelNames() []string {
 		i += 1
 	}
 	return labels
+}
+
+func (c *Config) RequestTimeout() time.Duration {
+	timeoutInMillis := c.RequestTimeoutMillis
+	if timeoutInMillis <= 0 {
+		timeoutInMillis = 500
+	}
+	return time.Duration(timeoutInMillis) * time.Millisecond
 }

--- a/exporter.go
+++ b/exporter.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"sync"
-	"time"
 
 	"github.com/golang/glog"
 	"github.com/prometheus/client_golang/prometheus"
@@ -32,9 +31,9 @@ type Exporter struct {
 }
 
 func NewExporter(servicesConfig *Config) *Exporter {
-	timeout := time.Duration(500 * time.Millisecond)
+	glog.Infof("Request timeout is %s", servicesConfig.RequestTimeout().String())
 	httpClient := &http.Client{
-		Timeout: timeout,
+		Timeout: servicesConfig.RequestTimeout(),
 	}
 
 	return &Exporter{


### PR DESCRIPTION
The hard-coded 500ms have proven to be not enough for some of our requests. So I added a command line flag to provide a custom timeout value.
